### PR TITLE
MULE-12366: Temporary Queues aren't deleted when JMS is used with BTM.

### DIFF
--- a/btm/src/main/java/bitronix/tm/resource/jms/MessageConsumerWrapper.java
+++ b/btm/src/main/java/bitronix/tm/resource/jms/MessageConsumerWrapper.java
@@ -90,7 +90,7 @@ public class MessageConsumerWrapper implements MessageConsumer {
     }
 
     public void close() throws JMSException {
-        // do nothing as the close is handled by the session handle
+        getMessageConsumer().close();
     }
 
     /* dumb wrapping of MessageProducer methods */

--- a/btm/src/main/java/bitronix/tm/resource/jms/MessageProducerWrapper.java
+++ b/btm/src/main/java/bitronix/tm/resource/jms/MessageProducerWrapper.java
@@ -95,7 +95,7 @@ public class MessageProducerWrapper implements MessageProducer {
     }
 
     public void close() throws JMSException {
-        // do nothing as the close is handled by the session handle
+        getMessageProducer().close();
     }
 
     /* dumb wrapping of MessageProducer methods */

--- a/btm/src/test/java/bitronix/tm/resource/jms/MessageConsumerWrapperTest.java
+++ b/btm/src/test/java/bitronix/tm/resource/jms/MessageConsumerWrapperTest.java
@@ -1,0 +1,53 @@
+/*
+ * Bitronix Transaction Manager
+ *
+ * Copyright (c) 2010, Bitronix Software.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA 02110-1301 USA
+ */
+
+package bitronix.tm.resource.jms;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import javax.jms.MessageConsumer;
+
+import junit.framework.TestCase;
+
+public class MessageConsumerWrapperTest extends TestCase {
+
+    private final DualSessionWrapper dualSessionWrapper = mock(DualSessionWrapper.class);
+    private final MessageConsumer messageConsumer = mock(MessageConsumer.class);
+    private final PoolingConnectionFactory poolingConnectionFactory = mock(PoolingConnectionFactory.class);
+    private final MessageConsumerWrapper messageConsumerWrapper = new MessageConsumerWrapper(messageConsumer, dualSessionWrapper, poolingConnectionFactory);
+
+    public void testMessageConsumerClosed() throws Exception {
+        messageConsumerWrapper.close();
+        verify(messageConsumer, times(1)).close();
+    }
+
+    public void testGetMessageSelector() throws Exception {
+        messageConsumerWrapper.getMessageSelector();
+        verify(messageConsumer, times(1)).getMessageSelector();
+    }
+
+    public void testGetMessageListener() throws Exception {
+        messageConsumerWrapper.getMessageListener();
+        verify(messageConsumer, times(1)).getMessageListener();
+    }
+}

--- a/btm/src/test/java/bitronix/tm/resource/jms/MessageProducerWrapperTest.java
+++ b/btm/src/test/java/bitronix/tm/resource/jms/MessageProducerWrapperTest.java
@@ -1,0 +1,75 @@
+/*
+ * Bitronix Transaction Manager
+ *
+ * Copyright (c) 2010, Bitronix Software.
+ *
+ * This copyrighted material is made available to anyone wishing to use, modify,
+ * copy, or redistribute it subject to the terms and conditions of the GNU
+ * Lesser General Public License, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this distribution; if not, write to:
+ * Free Software Foundation, Inc.
+ * 51 Franklin Street, Fifth Floor
+ * Boston, MA 02110-1301 USA
+ */
+
+package bitronix.tm.resource.jms;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import javax.jms.JMSException;
+import javax.jms.MessageProducer;
+import junit.framework.TestCase;
+
+public class MessageProducerWrapperTest extends TestCase {
+
+    private final DualSessionWrapper dualSessionWrapper = mock(DualSessionWrapper.class);
+    private final MessageProducer messageProducer= mock(MessageProducer.class);
+    private final PoolingConnectionFactory poolingConnectionFactory = mock(PoolingConnectionFactory.class);
+    private final MessageProducerWrapper messageProducerWrapper = new MessageProducerWrapper(messageProducer, dualSessionWrapper, poolingConnectionFactory);
+
+    public void testMessageConsumerClosed() throws Exception {
+        messageProducerWrapper.close();
+        verify(messageProducer, times(1)).close();
+    }
+
+    public void testGetDestination () throws JMSException {
+        messageProducerWrapper.getDestination();
+        verify(messageProducer, times(1)).getDestination();
+    }
+
+    public void testGetTimeToLive() throws JMSException {
+        messageProducerWrapper.getTimeToLive();
+        verify(messageProducer, times(1)).getTimeToLive();
+    }
+
+    public void testGetPriority() throws JMSException{
+        messageProducerWrapper.getPriority();
+        verify(messageProducer, times(1)).getPriority();
+    }
+
+    public void testGetDeliveryMode() throws JMSException{
+        messageProducerWrapper.getDeliveryMode();
+        verify(messageProducer, times(1)).getDeliveryMode();
+    }
+
+    public void testGetDisableMessageTimestamp() throws JMSException{
+        messageProducerWrapper.getDisableMessageTimestamp();
+        verify(messageProducer, times(1)).getDisableMessageTimestamp();
+    }
+
+    public void testGetDisableMessageID() throws JMSException{
+        messageProducerWrapper.getDisableMessageID();
+        verify(messageProducer, times(1)).getDisableMessageID();
+    }
+
+}
+


### PR DESCRIPTION
I have seen the comment "do nothing as the close is handled by the session handle".
However, I was looking for in BTM Code, and messageConsumer is never closed.
Even, DualSessionWrapper,  the single class that uses the MessageConsumerWrapper closes it using this method.
Additionally, we are closing the consumer from mule code using reflection invoking getMessageConsumer().close().