### PR TITLE
Rollback all unsucessful transactions during shutdown

### DIFF
--- a/btm/src/main/java/bitronix/tm/BitronixTransactionManager.java
+++ b/btm/src/main/java/bitronix/tm/BitronixTransactionManager.java
@@ -401,7 +401,7 @@ public class BitronixTransactionManager implements TransactionManager, UserTrans
 		inFlightTransactions.clear();
 	}
 
-	public String toString() {
+    public String toString() {
         return "a BitronixTransactionManager with " + inFlightTransactions.size() + " in-flight transaction(s)";
     }
 


### PR DESCRIPTION
to inform all resource holders (specially XA ones)
nothing more will happen here.
This avoids indoubt threads like
V466-THREAD HAS BEEN INDOUBT FOR 27:25:58
V451-RESYNC WITH COORDINATOR STILL PENDING