### PR TITLE
class of isValid maybe protected (e.g. SQLServerConnectionPoolProxy)

### DIFF
--- a/btm/src/main/java/bitronix/tm/resource/jdbc/JdbcPooledConnection.java
+++ b/btm/src/main/java/bitronix/tm/resource/jdbc/JdbcPooledConnection.java
@@ -124,6 +124,7 @@ public class JdbcPooledConnection extends AbstractXAResourceHolder implements St
 
         try {
             isValidMethod = connection.getClass().getMethod("isValid", Integer.TYPE);
+            isValidMethod.setAccessible(true);
             isValidMethod.invoke(connection, DETECTION_TIMEOUT); // test invoke
             jdbcVersionDetected = 4;
             if (!poolingDataSource.isEnableJdbc4ConnectionTest()) {


### PR DESCRIPTION
java.lang.IllegalAccessException: Class bitronix.tm.resource.jdbc.JdbcPooledConnection can not access a member of class com.microsoft.sqlserver.jdbc.SQLServerConnectionPoolProxy with modifiers "public"